### PR TITLE
Update Dockerfile with qt6-l10n-tools

### DIFF
--- a/jammy-qt5.15/Dockerfile
+++ b/jammy-qt5.15/Dockerfile
@@ -86,6 +86,7 @@ RUN set -x \
         qt6-base-private-dev \
         qt6-tools-dev \
         qt6-base-dev-tools \
+        qt6-l10n-tools \
         libqt6svg6-dev \
         xclip \
         xvfb \


### PR DESCRIPTION
Jammy has an older version of Qt6 that still requires the qt6-l10n-tools. Just adding qt6-tools-dev is not enough.