### PR TITLE
Update Dockerfile with qt6-tools-dev-tools

### DIFF
--- a/jammy-qt5.15/Dockerfile
+++ b/jammy-qt5.15/Dockerfile
@@ -86,6 +86,7 @@ RUN set -x \
         qt6-base-private-dev \
         qt6-tools-dev \
         qt6-base-dev-tools \
+        qt6-tools-dev-tools \
         qt6-l10n-tools \
         libqt6svg6-dev \
         xclip \


### PR DESCRIPTION
Jammy needs qt6-tools-dev-tools package for `lprodump` binary.