### PR TITLE
Add qt6-websockets-dev to Dockerfile

### DIFF
--- a/noble-qt5.15/Dockerfile
+++ b/noble-qt5.15/Dockerfile
@@ -89,6 +89,7 @@ RUN set -x \
         qt6-tools-dev \
         qt6-base-dev-tools \
         qt6-svg-dev \
+        qt6-websockets-dev \
         xclip \
         xvfb \
         zlib1g-dev \


### PR DESCRIPTION
Required by https://github.com/keepassxreboot/keepassxc/pull/12170