### PR TITLE
Add libqt6websockets6-dev to Dockerfile

### DIFF
--- a/jammy-qt5.15/Dockerfile
+++ b/jammy-qt5.15/Dockerfile
@@ -89,6 +89,7 @@ RUN set -x \
         qt6-tools-dev-tools \
         qt6-l10n-tools \
         libqt6svg6-dev \
+        libqt6websockets6-dev \
         xclip \
         xvfb \
         zlib1g-dev \


### PR DESCRIPTION
Required by https://github.com/keepassxreboot/keepassxc/pull/12170